### PR TITLE
Don't exit if $GOPATH/src is a symlink

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -18,6 +19,16 @@ func main() {
 	viper.AutomaticEnv()
 	gosrc := utils.GetGOPATH() + afero.FilePathSeparator + "src" + afero.FilePathSeparator
 	pwd, err := os.Getwd()
+	if err != nil {
+		logrus.Error(err)
+		return
+	}
+	gosrc, err = filepath.EvalSymlinks(gosrc)
+	if err != nil {
+		logrus.Error(err)
+		return
+	}
+	pwd, err = filepath.EvalSymlinks(pwd)
 	if err != nil {
 		logrus.Error(err)
 		return


### PR DESCRIPTION
EvalSymlinks() before comparing the `pwd` with $GOPATH/src so that in
the case where $GOPATH/src is a symbolic link (to a case sensitive
filesystem on a mac for instance) the `kit` command will still execute
successfully.

I'm not sure if this is too much of an edge case to handle in the code or not, but on my particular setup `$GOPATH/src` is a symlink to `Volumes/src`, which is a case-sensitive volume on my mac.  The reason for this is so that I don't have to worry about issues related to case insensitivity on the standard HFS+ volume.   

In theory, I could mitigate this issue by moving all of `$GOPATH` to /Volumes/src w/out having to change the code.  

Let me know what you think, and if this change is appropriate or not.  