### PR TITLE
Fix repair multiple GOPATH

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,12 +17,15 @@ func main() {
 	setDefaults()
 	viper.AutomaticEnv()
 	gosrc := utils.GetGOPATH() + afero.FilePathSeparator + "src" + afero.FilePathSeparator
+	gopath := strings.Split(gosrc, ";")[0]
 	pwd, err := os.Getwd()
 	if err != nil {
 		logrus.Error(err)
 		return
 	}
-	if !strings.HasPrefix(pwd, gosrc) {
+	if !strings.HasPrefix(pwd, gopath) {
+		logrus.Warn("---PWD:", pwd)
+		logrus.Warn("GOPATH:", gosrc)
 		logrus.Error("The project must be in the $GOPATH/src folder for the generator to work.")
 		return
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -57,6 +57,7 @@ func GoImportsSource(path string, s string) (string, error) {
 func GetServiceImportPath(name string) (string, error) {
 	gosrc := GetGOPATH() + "/src/"
 	gosrc = strings.Replace(gosrc, "\\", "/", -1)
+	gosrc = strings.Split(gosrc, ";")[0]
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -77,6 +78,7 @@ func GetServiceImportPath(name string) (string, error) {
 func GetCmdServiceImportPath(name string) (string, error) {
 	gosrc := GetGOPATH() + "/src/"
 	gosrc = strings.Replace(gosrc, "\\", "/", -1)
+	gosrc = strings.Split(gosrc, ";")[0]
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -97,6 +99,7 @@ func GetCmdServiceImportPath(name string) (string, error) {
 func GetEndpointImportPath(name string) (string, error) {
 	gosrc := GetGOPATH() + "/src/"
 	gosrc = strings.Replace(gosrc, "\\", "/", -1)
+	gosrc = strings.Split(gosrc, ";")[0]
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -117,6 +120,7 @@ func GetEndpointImportPath(name string) (string, error) {
 func GetGRPCTransportImportPath(name string) (string, error) {
 	gosrc := GetGOPATH() + "/src/"
 	gosrc = strings.Replace(gosrc, "\\", "/", -1)
+	gosrc = strings.Split(gosrc, ";")[0]
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -137,6 +141,7 @@ func GetGRPCTransportImportPath(name string) (string, error) {
 func GetPbImportPath(name string) (string, error) {
 	gosrc := GetGOPATH() + "/src/"
 	gosrc = strings.Replace(gosrc, "\\", "/", -1)
+	gosrc = strings.Split(gosrc, ";")[0]
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -157,6 +162,7 @@ func GetPbImportPath(name string) (string, error) {
 func GetHTTPTransportImportPath(name string) (string, error) {
 	gosrc := GetGOPATH() + "/src/"
 	gosrc = strings.Replace(gosrc, "\\", "/", -1)
+	gosrc = strings.Split(gosrc, ";")[0]
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -177,6 +183,7 @@ func GetHTTPTransportImportPath(name string) (string, error) {
 func GetDockerFileProjectPath() (string, error) {
 	gosrc := GetGOPATH() + "/src/"
 	gosrc = strings.Replace(gosrc, "\\", "/", -1)
+	gosrc = strings.Split(gosrc, ";")[0]
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fix repair multiple GOPATH 
like "E:\\CODE\\Go\\GoPath;E:\\CODE\\Git\\Github\\src" can't match pwd