### PR TITLE
Fix ending separator for the gopath

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	setDefaults()
 	viper.AutomaticEnv()
-	gosrc := utils.GetGOPATH() + afero.FilePathSeparator + "src" + afero.FilePathSeparator
+	gosrc := strings.TrimSuffix(utils.GetGOPATH(), afero.FilePathSeparator ) + afero.FilePathSeparator + "src" + afero.FilePathSeparator
 	pwd, err := os.Getwd()
 	if err != nil {
 		logrus.Error(err)


### PR DESCRIPTION
If the GOPATH contained an ending `/` kit does not run