### PR TITLE
switch from oklog/oklog/pkg/group to oklog/run

### DIFF
--- a/generator/generate_service.go
+++ b/generator/generate_service.go
@@ -1232,7 +1232,7 @@ func (g *generateCmdBase) Generate() (err error) {
 	}
 	cd := []jen.Code{
 		jen.Id("g").Op("=").Id("&").Qual(
-			"github.com/oklog/oklog/pkg/group", "Group",
+			"github.com/oklog/run", "Group",
 		).Block(),
 	}
 	if existingHTTP {
@@ -1265,7 +1265,7 @@ func (g *generateCmdBase) Generate() (err error) {
 			jen.Id("endpoints").Qual(endpointImport, "Endpoints"),
 		},
 		[]jen.Code{
-			jen.Id("g").Id("*").Qual("github.com/oklog/oklog/pkg/group", "Group"),
+			jen.Id("g").Id("*").Qual("github.com/oklog/run", "Group"),
 		},
 		"",
 		cd...,
@@ -1924,7 +1924,7 @@ func (g *generateCmd) generateInitHTTP() (err error) {
 		nil,
 		[]jen.Code{
 			jen.Id("endpoints").Qual(epImport, "Endpoints"),
-			jen.Id("g").Id("*").Qual("github.com/oklog/oklog/pkg/group", "Group"),
+			jen.Id("g").Id("*").Qual("github.com/oklog/run", "Group"),
 		},
 		[]jen.Code{},
 		"",
@@ -2007,7 +2007,7 @@ func (g *generateCmd) generateInitGRPC() (err error) {
 		nil,
 		[]jen.Code{
 			jen.Id("endpoints").Qual(epImport, "Endpoints"),
-			jen.Id("g").Id("*").Qual("github.com/oklog/oklog/pkg/group", "Group"),
+			jen.Id("g").Id("*").Qual("github.com/oklog/run", "Group"),
 		},
 		[]jen.Code{},
 		"",
@@ -2106,7 +2106,7 @@ func (g *generateCmd) generateDefaultMetrics() {
 			"initMetricsEndpoint",
 			nil,
 			[]jen.Code{
-				jen.Id("g").Id("*").Qual("github.com/oklog/oklog/pkg/group", "Group"),
+				jen.Id("g").Id("*").Qual("github.com/oklog/run", "Group"),
 			},
 			[]jen.Code{},
 			"",
@@ -2159,7 +2159,7 @@ func (g *generateCmd) generateCancelInterrupt() {
 			"initCancelInterrupt",
 			nil,
 			[]jen.Code{
-				jen.Id("g").Id("*").Qual("github.com/oklog/oklog/pkg/group", "Group"),
+				jen.Id("g").Id("*").Qual("github.com/oklog/run", "Group"),
 			},
 			[]jen.Code{},
 			"",


### PR DESCRIPTION
The former is archived, and just [re-export the Group type from oklog/run](https://github.com/oklog/oklog/blob/master/pkg/group/group.go).